### PR TITLE
Support relative topicPattern without requiring full tenant/namespace prefix #1240

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
@@ -18,7 +18,9 @@ package org.springframework.pulsar.reactive.core;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumer;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumerBuilder;
@@ -97,6 +99,12 @@ public class DefaultReactivePulsarConsumerFactory<T> implements ReactivePulsarCo
 		if (!CollectionUtils.isEmpty(topics)) {
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			mutableSpec.setTopicNames(fullyQualifiedTopics);
+		}
+		var topicsPattern = mutableSpec.getTopicsPattern();
+		if (topicsPattern != null && StringUtils.isNoneBlank(topicsPattern.pattern())) {
+			var topicsPatternStr = topicsPattern.pattern();
+			var fullyQualifiedTopicsPatternStr = this.topicBuilder.getFullyQualifiedNameForTopic(topicsPatternStr);
+			mutableSpec.setTopicsPattern(Pattern.compile(fullyQualifiedTopicsPatternStr));
 		}
 	}
 

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
@@ -87,6 +87,7 @@ public class DefaultReactivePulsarConsumerFactory<T> implements ReactivePulsarCo
 			customizers.forEach((c) -> c.customize(consumerBuilder));
 		}
 		this.ensureTopicNamesFullyQualified(consumerBuilder);
+		this.ensureTopicsPatternFullyQualified(consumerBuilder);
 		return consumerBuilder.build();
 	}
 
@@ -100,6 +101,13 @@ public class DefaultReactivePulsarConsumerFactory<T> implements ReactivePulsarCo
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			mutableSpec.setTopicNames(fullyQualifiedTopics);
 		}
+	}
+
+	protected void ensureTopicsPatternFullyQualified(ReactiveMessageConsumerBuilder<T> consumerBuilder) {
+		if (this.topicBuilder == null) {
+			return;
+		}
+		var mutableSpec = consumerBuilder.getMutableSpec();
 		var topicsPattern = mutableSpec.getTopicsPattern();
 		if (topicsPattern != null && StringUtils.isNoneBlank(topicsPattern.pattern())) {
 			var topicsPatternStr = topicsPattern.pattern();

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -145,6 +147,12 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 		if (!CollectionUtils.isEmpty(topics)) {
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			builderImpl.getConf().setTopicNames(new HashSet<>(fullyQualifiedTopics));
+		}
+		var topicsPattern = builderImpl.getConf().getTopicsPattern();
+		if (topicsPattern != null && StringUtils.isNoneBlank(topicsPattern.pattern())) {
+			var topicsPatternStr = topicsPattern.pattern();
+			var fullyQualifiedTopicsPatternStr = this.topicBuilder.getFullyQualifiedNameForTopic(topicsPatternStr);
+			builderImpl.getConf().setTopicsPattern(Pattern.compile(fullyQualifiedTopicsPatternStr));
 		}
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -119,6 +119,7 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 			customizers.forEach(customizer -> customizer.customize(consumerBuilder));
 		}
 		this.ensureTopicNamesFullyQualified(consumerBuilder);
+		this.ensureTopicsPatternFullyQualified(consumerBuilder);
 		try {
 			return consumerBuilder.subscribe();
 		}
@@ -148,6 +149,13 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			builderImpl.getConf().setTopicNames(new HashSet<>(fullyQualifiedTopics));
 		}
+	}
+
+	protected void ensureTopicsPatternFullyQualified(ConsumerBuilder<T> builder) {
+		if (this.topicBuilder == null) {
+			return;
+		}
+		var builderImpl = (ConsumerBuilderImpl<T>) builder;
 		var topicsPattern = builderImpl.getConf().getTopicsPattern();
 		if (topicsPattern != null && StringUtils.isNoneBlank(topicsPattern.pattern())) {
 			var topicsPatternStr = topicsPattern.pattern();


### PR DESCRIPTION
See [Support relative topicPattern without requiring full tenant/namespace prefix #1240](https://github.com/spring-projects/spring-pulsar/issues/1240).
Call getFullyQualifiedNameForTopic(topicsPattern) and re-set topicsPattern in consumerBuilder. See DefaultPulsarConsumerFactory and DefaultReactivePulsarConsumerFactory.